### PR TITLE
Close #5 by implementing file extension mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,23 @@ Add to your `book.json` plugin list:
 }
 ```
 
-
-##TODO
-Add convenient way to map file extensions that don't match syntax used in contents.
-
-Currently only Gherkin feature files used for example in Cucumber
+## Configuration
+You can map file extensions that don't match syntax used in contents by adding a mapping in your `book.json` plugins config section:
 ```
-almostGreat.feature
+"pluginsConfig": {
+  "include-highlight": {
+    "extensionToLanguage": {
+      "ps1": "powershell"
+    }
+  }
+}
 ```
-are mapped to use gherkin as highlight.
+
+The plugin is pre-configured with the following mappings:
+```
+{
+	'feature': 'gherkin',
+	'pde': 'processing',
+	'ps1': 'powershell'
+}
+```

--- a/index.js
+++ b/index.js
@@ -5,12 +5,15 @@ var Q = require('q');
 var extensionToLanguage = {
 	'feature': 'gherkin',
 	'pde': 'processing',
+	'ps1': 'powershell',
 };
 
 module.exports = {
 
 	hooks: {
 		"page:before": function(page) {
+			var that = this;
+			var pluginConfig = that.options.pluginsConfig['include-highlight'] || {};
 			var re = /^!CODEFILE\s+(?:\"([^\"]+)\"|'([^']+)')\s*$/gm;
 
 			var dir = path.dirname(page.rawPath);
@@ -22,7 +25,14 @@ module.exports = {
 			var getCodeLang = function(filepath) {
 				var lang = "";
 				var suffix = filepath.split(".").pop();
-				
+
+				// naively merge config object with language lookup
+				if (pluginConfig.extensionToLanguage) {
+					for (var ext in pluginConfig.extensionToLanguage) {
+						extensionToLanguage[ext] = pluginConfig.extensionToLanguage[ext];
+					}
+				}
+
 				// look up if mapping from suffix to language exists,
 				// otherwise use `suffix`
 				lang = extensionToLanguage[suffix] || suffix;


### PR DESCRIPTION
Adds support for configuring the plugin using the book.json file to add mappings from file extension to language.

Described in issue #5.

If you decide to merge the pull request it would be great if you could bump the version number and publish a new package to NPM. GitBook has a pretty bad plugin architecture where the plugins has to be available on the public NPM repository, making it hard to use this fix unless I publish my own forked package.
