### PR TITLE
Removing built in module 'fs' from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
 	},
 	"dependencies": {
 		"q": "*",
-		"path":"*",
-		"fs":"*"
+		"path":"*"
 	},
 	"homepage": "https://github.com/junakowicz/gitbook-plugin-include-highlight",
 	"repository": {


### PR DESCRIPTION
npm package 'fs' should not be used anymore.

'gitbook install' with include-highlight results in the following error:
info: installing plugin "include-highlight"
info: install plugin "include-highlight" (*) from NPM with version 0.2.0

Error: Error extracting C:\Users\username\AppData\Roaming\npm-cache\fs\0.0.0\package.tgz archive: ENOENT: no such file or directory, open 'C:\Users\username\AppData\Roaming\npm-cache\fs\0.0.0\package.tgz' 